### PR TITLE
Probable fix for Ticking TIle Entity NPE on Fluid Fill when neighboring pipe is broken.

### DIFF
--- a/additionalpipes/pipes/PipeLiquidsTeleport.java
+++ b/additionalpipes/pipes/PipeLiquidsTeleport.java
@@ -58,7 +58,9 @@ public class PipeLiquidsTeleport extends PipeTeleport implements IPipeTransportF
 		for(ForgeDirection o : ForgeDirection.VALID_DIRECTIONS) {
 			if(pipe.outputOpen(o)) {
 				IFluidHandler te = (IFluidHandler) pipe.container.getTile(o);
-				result.add(te);
+				if (te != null) {
+					result.add(te);
+				}
 			}
 		}
 


### PR DESCRIPTION
From brief testing, this appears to resolve issues #94 and #82
