### PR TITLE
Fix gravity feed pipe extracting items at much higher speed than intended

### DIFF
--- a/src/main/java/buildcraft/additionalpipes/APConfiguration.java
+++ b/src/main/java/buildcraft/additionalpipes/APConfiguration.java
@@ -72,7 +72,7 @@ public class APConfiguration
 			waterPerTickProperty.setComment("Amount of water the Water Pump Pipe produces in millibuckets/tick");
 			waterPumpWaterPerTick = waterPerTickProperty.getInt();
 			
-			Property gpPullRateProperty = config.get(Configuration.CATEGORY_GENERAL, "gravityFeedPipeTicksPerPull", 48);
+			Property gpPullRateProperty = config.get(Configuration.CATEGORY_GENERAL, "gravityFeedPipeTicksPerPull", 20);
 			gpPullRateProperty.setComment("How many ticks the Gravity Feed Pipe needs to extract an item");
 			gravityFeedPipeTicksPerPull = gpPullRateProperty.getInt();
 			

--- a/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorGravityFeed.java
+++ b/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorGravityFeed.java
@@ -48,7 +48,7 @@ public class PipeBehaviorGravityFeed extends APPipe
 			{
 				((PipeFlowItems)pipe.getFlow()).tryExtractItems(1, EnumFacing.UP, null, StackFilter.ALL, false);
 			}
-
+			ticksSincePull = 0;
 		}
 	}
 


### PR DESCRIPTION
Sorry but this was never meant to be this OP. Now it obeys the configuration setting though, so you can get the bugged behavior back by changing that.