### PR TITLE
Try and fix distribution pipe hang

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Compiled binaries can be found in `build/libs`.
     
 ### Setting Up Eclipse ###
 1. Install Eclipse JDK.
+2. If your PC uses Java newer than 8 by default, update your `JAVA_HOME` environment variable to point to JDK 8.
 2. Run the command `gradlew setupDecompWorkspace --refresh-dependencies eclipse`
 3. In Eclipse, go to `File > Import... > General > Existing Projects into Workspace`
 4. Hit Next.  Click Browse... in the top right, and select the directory you cloned Additional Pipes into.  Check the box next to AdditionalPipesBC in the Projects list.

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 apply plugin: 'net.minecraftforge.gradle.forge'
 
-version = "6.0.0.8"
+version = "6.0.1"
 group= "com.buildcraft.additionalpipes" 
 archivesBaseName = "additionalpipes"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx4096M
 mc_version=1.12.2
 jei_version=4.8.5.142
+net.minecraftforge.gradle.disableUpdateChecker=true

--- a/src/main/java/buildcraft/additionalpipes/item/ItemDogDeaggravator.java
+++ b/src/main/java/buildcraft/additionalpipes/item/ItemDogDeaggravator.java
@@ -40,8 +40,8 @@ public class ItemDogDeaggravator extends Item
     {
 		//this code adapted from EntityAIHurtByTarget.startExecuting()
 		double horizontalRange = 16;
-        List<EntityWolf> list = world.getEntitiesWithinAABB(EntityWolf.class, new AxisAlignedBB(player.posX, player.posY, player.posZ,
-        		player.posX + 1.0D, player.posY + 1.0D, player.posZ + 1.0D).grow(horizontalRange, 10.0D, horizontalRange));
+        List<EntityWolf> list = world.getEntitiesWithinAABB(EntityWolf.class, new AxisAlignedBB(player.posX, player.posY + 1.0D, player.posZ,
+        		player.posX, player.posY + 1.0D, player.posZ).grow(horizontalRange, 10.0D, horizontalRange));
         Iterator<EntityWolf> iterator = list.iterator();
         int wolfCounter = 0;
 

--- a/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorDistribution.java
+++ b/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorDistribution.java
@@ -117,6 +117,8 @@ public class PipeBehaviorDistribution extends APPipe {
 					{
 						if(!toNextOpenSide())
 						{
+							// *shouldn't* be possible to get here due to the sideCheck() event handler, but keeping this logic just in case as
+							// otherwise we would hit an infinite hang.
 							Log.error("Failed to distribute itemstack. Allowing it to be routed randomly.");
 							entry.to.clear();
 							newDistribution.add(entry);
@@ -149,16 +151,13 @@ public class PipeBehaviorDistribution extends APPipe {
 	 * @return true if there is another open side that can accept an item stack, false otherwise.
 	 */
 	private boolean toNextOpenSide() 
-	{
-		EnumFacing lastDistSide = distSide;
-		
+	{		
 		itemsThisSide = 0;
 		for(int o = 0; o < distData.length; ++o) 
 		{
 			distSide = EnumFacing.VALUES[(distSide.ordinal() + 1) % distData.length];
 			if(distData[distSide.ordinal()] > 0 && pipe.isConnected(distSide))
 			{
-				Log.debug("toNextOpenSide(): distSide changed: " + lastDistSide + "-> " + distSide);
 				return true;
 			}
 		}


### PR DESCRIPTION
This issue was very helpfully described by @Rishum-P here: https://github.com/tcooc/AdditionalPipesBC/pull/203#discussion_r2392945590

I tried to reproduce it and I believe it's actually even easier to cause than described. You just need to have a distribution pipe with 0 values for all connected sides. Feeding items into that pipe is enough to cause an infinite loop and eventual crash (when running in singleplayer).

As I understand, this issue basically happens because toNextOpenSide() only tries all possible open sides once before giving up and returning. So if we are in a situation where no side is a valid destination for items, we will just get stuck in the while loop in splitStacks() forever and ever.

I added two different protections against this issue happening. First of all, `toNextOpenSide()` now returns false if it cannot find a valid side, and in this situation we just set no specific destination for the item stack. This fixes the crash, and causes buildcraft to route the item stack randomly.

However, I wanted un-routable items to be dropped on the ground, so I added a new `sideCheck()` event handler which disallows items from going to any side that has a distribution amount of 0. This should only have one effect, which is to cause items to be dropped unless there is at least one connected side that has a distribution amount greater than 0.