### PR TITLE
Fixed teleport pipes with undefined pipe behaviour being added to the teleport manager.

### DIFF
--- a/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorTeleport.java
+++ b/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorTeleport.java
@@ -45,12 +45,6 @@ public abstract class PipeBehaviorTeleport extends APPipe implements ITeleportPi
 	{
 		super(pipe);
 		this.type = type;
-		
-		if(isServer())
-		{
-			TeleportManager.instance.add(this, frequency);
-		}
-
 	}
 	
 	public PipeBehaviorTeleport(IPipe pipe, NBTTagCompound tagCompound, TeleportPipeType type)
@@ -66,11 +60,6 @@ public abstract class PipeBehaviorTeleport extends APPipe implements ITeleportPi
 			ownerName = tagCompound.getString("ownerName");
 		}
 		isPublic = tagCompound.getBoolean("isPublic");
-		
-		if(isServer())
-		{
-			TeleportManager.instance.add(this, frequency);
-		}
 	}
 	
 	@Override
@@ -151,6 +140,7 @@ public abstract class PipeBehaviorTeleport extends APPipe implements ITeleportPi
 		if(isServer())
 		{
 			Log.debug("Teleport pipe at " + getPos() + " validated");
+			TeleportManager.instance.add(this, frequency);
 		}
 	}
 


### PR DESCRIPTION
Fixed teleport pipes that were removed when the chuck was unloaded, to be added back when the chuck is loaded.

Adding the teleport pipe to the teleport manager in the constructor causes pipes to be added that have no pipe behaviour defined yet and thus return null. Moving it to onValidate fixes this.