### PR TITLE
Fixed switch pipes not getting a block update

### DIFF
--- a/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorSwitch.java
+++ b/src/main/java/buildcraft/additionalpipes/pipes/PipeBehaviorSwitch.java
@@ -1,7 +1,6 @@
 package buildcraft.additionalpipes.pipes;
 
 import buildcraft.api.transport.pipe.IPipe;
-import buildcraft.api.transport.pipe.IPipeHolder.PipeMessageReceiver;
 import buildcraft.api.transport.pipe.PipeBehaviour;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
@@ -49,7 +48,7 @@ public class PipeBehaviorSwitch extends APPipe
 		if(canConnect != newCanConnect)
 		{
 			canConnect = newCanConnect;
-			pipe.getHolder().scheduleNetworkUpdate(PipeMessageReceiver.BEHAVIOUR);
+			pipe.markForUpdate();
 		}
 	}
 	


### PR DESCRIPTION
The old method seems to not work anymore, and pipe.markForUpdate() appears to be it's replacement