### PR TITLE
Teleport tether item model fix

### DIFF
--- a/src/main/java/buildcraft/additionalpipes/MultiPlayerProxyClient.java
+++ b/src/main/java/buildcraft/additionalpipes/MultiPlayerProxyClient.java
@@ -30,12 +30,9 @@ public class MultiPlayerProxyClient extends MultiPlayerProxy
 	public void registerRendering()
 	{
 		RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
-		
-		if(APConfiguration.enableChunkloaderRecipe)
-		{
-			renderItem.getItemModelMesher().register(Item.getItemFromBlock(AdditionalPipes.instance.blockTeleportTether), 0, 
-					new ModelResourceLocation(AdditionalPipes.instance.blockTeleportTether.getRegistryName(), "inventory"));
-		}
+
+		renderItem.getItemModelMesher().register(Item.getItemFromBlock(AdditionalPipes.instance.blockTeleportTether), 0,
+				new ModelResourceLocation(AdditionalPipes.instance.blockTeleportTether.getRegistryName(), "inventory"));
 		
 	     renderItem.getItemModelMesher().register(AdditionalPipes.instance.dogDeaggravator, 0, 
 	    		 new ModelResourceLocation(AdditionalPipes.MODID + ":" + ItemDogDeaggravator.NAME, "inventory"));

--- a/src/main/java/buildcraft/additionalpipes/chunkloader/BlockTeleportTether.java
+++ b/src/main/java/buildcraft/additionalpipes/chunkloader/BlockTeleportTether.java
@@ -1,12 +1,22 @@
 package buildcraft.additionalpipes.chunkloader;
 
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import buildcraft.additionalpipes.APConfiguration;
 import buildcraft.additionalpipes.AdditionalPipes;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.resources.I18n;
+import net.minecraft.client.util.ITooltipFlag;
+import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class BlockTeleportTether extends BlockContainer {
 
@@ -40,5 +50,14 @@ public class BlockTeleportTether extends BlockContainer {
     public EnumBlockRenderType getRenderType(IBlockState state)
     {
         return EnumBlockRenderType.MODEL;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, @Nullable World worldIn, List<String> list, ITooltipFlag flagIn)
+    {
+        if(!APConfiguration.enableChunkloaderRecipe) {
+            list.add(I18n.format("tooltip.teleport_tether_crafting_disabled"));
+        }
     }
 }

--- a/src/main/resources/assets/additionalpipes/lang/en_us.lang
+++ b/src/main/resources/assets/additionalpipes/lang/en_us.lang
@@ -87,6 +87,8 @@ tip.teleportPipe=No more long pipelines!
 
 tooltip.dog_deaggravator=Calms down your dogs
 
+tooltip.teleport_tether_crafting_disabled=Crafting disabled by config
+
 itemGroup.apcreativetab=Additional Pipes
 
 # chat stuff


### PR DESCRIPTION
Fixes teleport tether having no item model if enableChunkloaderRecipe=false
Added a tooltip to the teleport tether if enableChunkloaderRecipe=false, saying "crafting disabled by config"